### PR TITLE
Bumps version number to 1.0.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ summary =
     A lightweight proof of concept Monasca monitor
 home-page = https://github.com/stackhpc/monasca-monitor
 license = Apache-2
-version = 0.1
+version = 1.0.1
 classifier =
     Development Status :: 4 - Beta
         Intended Audience :: Developers


### PR DESCRIPTION
Fixes semantic versioning CI issue introduced by adding 1.0.0 tag to master.